### PR TITLE
Feature/read consistency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamo-types",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "DynamoDB ORM for Typescript",
   "main": "./dst/index.js",
   "typings": "./dst/index.d.ts",

--- a/src/query/full_primary_key.ts
+++ b/src/query/full_primary_key.ts
@@ -33,7 +33,12 @@ export class FullPrimaryKey<T extends Table, HashKeyType, RangeKeyType> {
     }).promise();
   }
 
-  async get(hashKey: HashKeyType, sortKey: RangeKeyType): Promise<T | null> {
+  /**
+   * @param hashKey - HashKey
+   * @param sortKey - sortKey
+   * @param options - read options. consistent means "strongly consistent" or not
+   */
+  async get(hashKey: HashKeyType, sortKey: RangeKeyType, options: { consistent: boolean } = { consistent: false } ): Promise<T | null> {
     const dynamoRecord =
       await this.documentClient.get({
         TableName: this.tableClass.metadata.name,
@@ -41,6 +46,7 @@ export class FullPrimaryKey<T extends Table, HashKeyType, RangeKeyType> {
           [this.metadata.hash.name]: hashKey,
           [this.metadata.range.name]: sortKey,
         },
+        ConsistentRead: options.consistent,
       }).promise();
     if (!dynamoRecord.Item) {
       return null;
@@ -91,6 +97,7 @@ export class FullPrimaryKey<T extends Table, HashKeyType, RangeKeyType> {
     rangeOrder?: "ASC" | "DESC",
     limit?: number,
     exclusiveStartKey?: DynamoDB.DocumentClient.Key,
+    consistent?: boolean,
   }) {
     if (!options.rangeOrder) {
       options.rangeOrder = "ASC";
@@ -110,6 +117,7 @@ export class FullPrimaryKey<T extends Table, HashKeyType, RangeKeyType> {
       ExpressionAttributeValues: {
         [HASH_VALUE_REF]: options.hash,
       },
+      ConsistentRead: options.consistent
     };
 
     if (options.range) {

--- a/src/query/global_secondary_index.ts
+++ b/src/query/global_secondary_index.ts
@@ -25,6 +25,7 @@ export class FullGlobalSecondaryIndex<T extends Table, HashKeyType, RangeKeyType
     rangeOrder?: "ASC" | "DESC",
     limit?: number,
     exclusiveStartKey?: DynamoDB.DocumentClient.Key,
+    consistent?: boolean,
   }) {
     if (!options.rangeOrder) {
       options.rangeOrder = "ASC";
@@ -45,6 +46,7 @@ export class FullGlobalSecondaryIndex<T extends Table, HashKeyType, RangeKeyType
       ExpressionAttributeValues: {
         [HASH_VALUE_REF]: options.hash,
       },
+      ConsistentRead: options.consistent,
     };
 
     if (options.range) {
@@ -75,7 +77,7 @@ export class HashGlobalSecondaryIndex<T extends Table, HashKeyType> {
     readonly documentClient: DynamoDB.DocumentClient
   ) {}
 
-  async query(hash: HashKeyType, options: { limit?: number } = {}) {
+  async query(hash: HashKeyType, options: { limit?: number, consistent?: boolean } = {}) {
     const params: DynamoDB.DocumentClient.QueryInput = {
       TableName: this.tableClass.metadata.name,
       IndexName: this.metadata.name,
@@ -88,6 +90,7 @@ export class HashGlobalSecondaryIndex<T extends Table, HashKeyType> {
       ExpressionAttributeValues: {
         [HASH_VALUE_REF]: hash,
       },
+      ConsistentRead: options.consistent,
     };
 
     const result = await this.documentClient.query(params).promise();

--- a/src/query/hash_primary_key.ts
+++ b/src/query/hash_primary_key.ts
@@ -29,13 +29,14 @@ export class HashPrimaryKey<T extends Table, HashKeyType> {
     }).promise();
   }
 
-  async get(hashKey: HashKeyType): Promise<T | null> {
+  async get(hashKey: HashKeyType, options: { consistent: boolean } = { consistent: false }): Promise<T | null> {
     const dynamoRecord =
       await this.documentClient.get({
         TableName: this.tableClass.metadata.name,
         Key: {
           [this.metadata.hash.name]: hashKey,
         },
+        ConsistentRead: options.consistent,
       }).promise();
     if (!dynamoRecord.Item) {
       return null;

--- a/src/query/local_secondary_index.ts
+++ b/src/query/local_secondary_index.ts
@@ -25,6 +25,7 @@ export class LocalSecondaryIndex<T extends Table, HashKeyType, RangeKeyType> {
     rangeOrder?: "ASC" | "DESC",
     limit?: number,
     exclusiveStartKey?: DynamoDB.DocumentClient.Key,
+    consistent?: boolean
   }) {
     if (!options.rangeOrder) {
       options.rangeOrder = "ASC";
@@ -45,6 +46,7 @@ export class LocalSecondaryIndex<T extends Table, HashKeyType, RangeKeyType> {
       ExpressionAttributeValues: {
         [HASH_VALUE_REF]: options.hash,
       },
+      ConsistentRead: options.consistent,
     };
 
     if (options.range) {


### PR DESCRIPTION
DynamoDB has concept of "Eventually Consistent" / "Strongly Consistent" 
[AWS Docs](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadConsistency.html)
as a default, it's eventually consistent.
mostly we don't really need to think about this, but it seems like card-interest caching problem is actually caused by this. so to have execute read queries in Strongly Consistent manner.
