### PR TITLE
fix error message couldn't show up correctly

### DIFF
--- a/src/query/writer.ts
+++ b/src/query/writer.ts
@@ -22,7 +22,7 @@ export class Writer<T extends Table> {
       record.setAttributes(res.Attributes || {});
       return record;
     } catch (e) {
-      console.log(`Dynamo-Types Put - ${JSON.stringify(record, null, 2)}`);
+      console.log(`Dynamo-Types Put - ${JSON.stringify(record.serialize(), null, 2)}`);
       throw e;
     }
   }


### PR DESCRIPTION
at this moment, dynamo-types can't show error message correctly.

expected error message or stack trace is like below:

<img width="962" alt="2018-01-06 7 08 15" src="https://user-images.githubusercontent.com/2101743/34630809-01c9f5c0-f2b1-11e7-8a65-6845553e5bf8.png">

but actual error message that we got: 

<img width="953" alt="2018-01-06 7 04 50" src="https://user-images.githubusercontent.com/2101743/34630862-37a50356-f2b1-11e7-9316-011c873aff8c.png">

when table tries to log table instance if something went wrong during writing item, we call `JSON.stringify` to get JSON.

In theory, `JSON.stringify` traverses entire object (think tree structure), so if any leaf node has circular reference, process cannot to be ended. and that's why `JSON.stringify` throws circular reference error.

anyway we can prevent this error by logging attributes only, so i've applied that workaround



  