### PR TITLE
Feature/backend 1020

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamo-types",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "DynamoDB ORM for Typescript",
   "main": "./dst/index.js",
   "typings": "./dst/index.d.ts",

--- a/src/query/__test__/full_primary_key_spec.ts
+++ b/src/query/__test__/full_primary_key_spec.ts
@@ -108,14 +108,26 @@ describe("FullPrimaryKey", () => {
         }
       }).promise();
 
-      const items = (await primaryKey.batchGet([
+      const items1 = (await primaryKey.batchGet([
         [10, "abc"],
         [11, "abc"]
       ])).records;
-      expect(items.length).to.eq(2);
+      expect(items1.length).to.eq(2);
+      expect(items1[0].id).to.eq(10);
+      expect(items1[1].id).to.eq(11);
 
-      expect(items[0].id).to.eq(10);
-      expect(items[1].id).to.eq(11);
+
+      const items2 = (await primaryKey.batchGetFull([
+        [10, "abc"],
+        [10000, "asdgasdgs"],
+        [11, "abc"],
+      ])).records;
+      expect(items2.length).to.eq(3);
+      expect(items2[0]!.id).to.eq(10);
+      expect(items2[0]!.title).to.eq("abc");
+      expect(items2[1]).to.eq(undefined);
+      expect(items2[2]!.id).to.eq(11);
+      expect(items2[2]!.title).to.eq("abc");
     });
   });
 

--- a/src/query/__test__/hash_primary_key_spec.ts
+++ b/src/query/__test__/hash_primary_key_spec.ts
@@ -108,10 +108,10 @@ describe("HashPrimaryKey", () => {
         await createCard(),
       ];
 
-      const result = (await primaryKey.batchGet(cards.map(c => c.id))).records;
+      const result1 = (await primaryKey.batchGet(cards.map(c => c.id))).records;
 
       // it should keep the order
-      expect(result.map(c => c.id)).to.deep.eq(cards.map(c => c.id));
+      expect(result1.map(c => c.id)).to.deep.eq(cards.map(c => c.id));
     });
   });
 });

--- a/src/query/hash_primary_key.ts
+++ b/src/query/hash_primary_key.ts
@@ -5,7 +5,7 @@ import * as Metadata from '../metadata';
 import * as Codec from '../codec';
 
 import { batchWrite } from "./batch_write";
-import { batchGet } from "./batch_get";
+import { batchGetFull, batchGetTrim } from "./batch_get";
 import * as Scan from "./scan";
 
 const HASH_KEY_REF = "#hk";
@@ -74,7 +74,7 @@ export class HashPrimaryKey<T extends Table, HashKeyType> {
   }
 
   async batchGet(keys: Array<HashKeyType>) {
-    const res = await batchGet(
+    const res = await batchGetTrim(
       this.tableClass.metadata.connection.documentClient,
       this.tableClass.metadata.name,
       keys.map((key) => {
@@ -87,6 +87,24 @@ export class HashPrimaryKey<T extends Table, HashKeyType> {
     return {
       records: res.map(item => {
         return Codec.deserialize(this.tableClass, item);
+      })
+    };
+  }
+
+  async batchGetFull(keys: Array<HashKeyType>) {
+    const res = await batchGetFull(
+      this.tableClass.metadata.connection.documentClient,
+      this.tableClass.metadata.name,
+      keys.map((key) => {
+        return {
+          [this.metadata.hash.name]: key,
+        }
+      })
+    );
+
+    return {
+      records: res.map(item => {
+        return item ? Codec.deserialize(this.tableClass, item) : undefined;
       })
     };
   }


### PR DESCRIPTION
Introducing  #BatchGetFull

Currently batchGet keeps the "order" of given keys at return values, but doesn't care about "missing values"
```
items: [1-a,2-b,3-c],
BatchGet([3, 2, 1]) ==> [3-c, 2-b, 1-a],
```
But
``` 
BatchGet([3, 4, 2, 1]) ==> [3-c, 2-b, 1-a],
```
which cause some problems and cause extra codes for detecting this... etc.
instead, 

``` 
BatchGetFull([3, 4, 2, 1]) ==> [3-c, undefined, 2-b, 1-a],
```
So always **keys.length == values.length**

return type also diversified,
```
BatchGet => Array<T>
BatchGetFull => Array<T|undefined>
```


